### PR TITLE
Convert HTML episode descriptions to text

### DIFF
--- a/src/components/EpisodeCard.tsx
+++ b/src/components/EpisodeCard.tsx
@@ -2,6 +2,7 @@ import { MouseEventHandler, useRef } from 'react'
 import { EpisodeData } from '..'
 import * as icons from '../Icons'
 import { useNavigate } from 'react-router-dom'
+import { stripAllHTML } from '../utils/stripAllHTML'
 import { secondsToStr } from '../utils/utils'
 import ProgressBar from './ProgressBar'
 import { useTranslation } from 'react-i18next'
@@ -83,7 +84,7 @@ function EpisodeCard({
           <p className={`text-sm ${reprState.complete ? '0' : '-4'}`}>
             {getDateString()} - {episode.size} MB{' '}
           </p>
-          <h2 className="mb-2" title={episode.description}>
+          <h2 className="mb-2" title={stripAllHTML(episode.description)}>
             {episode.title}
           </h2>
           <div className="flex w-full items-center justify-end gap-2">

--- a/src/utils/stripAllHTML.ts
+++ b/src/utils/stripAllHTML.ts
@@ -1,0 +1,16 @@
+import DOMPurify from 'dompurify'
+
+const newlineTags = new Set([ 'P', 'DIV', 'BR', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6']);
+
+// If the tag implies a newline, add a newline. Otherwise ignore.
+DOMPurify.addHook('uponSanitizeElement', function (node) {
+    if (node.tagName && newlineTags.has(node.tagName)) {
+        node.textContent += '\n';
+    }
+});
+
+export function stripAllHTML(htmlString: string) {
+    return DOMPurify.sanitize( htmlString, {
+        ALLOWED_TAGS:[]}
+    ).trim();
+}


### PR DESCRIPTION
Attempts to extract text from HTML episode descriptions. Newlines are added in place of header, paragraph, and line break tags.

Fixes #49