### PR TITLE
Add tooltips on podcast page

### DIFF
--- a/resources/translations/en.json
+++ b/resources/translations/en.json
@@ -93,5 +93,9 @@
   "import_opml": "Import OPML file subscriptions",
   "export_opml": "Export subscriptions to OPML file",
   "change_podcast_cover": "Change the podcast cover",
-  "podcast_cover_url": "URL to the podcast cover"
+  "podcast_cover_url": "URL to the podcast cover",
+  "sort_episodes": "Sort",
+  "filter_episodes": "Filter",
+  "podcast_settings": "Settings",
+  "podcast_refresh": "Refresh"
 }

--- a/src/pages/PodcastPreview.tsx
+++ b/src/pages/PodcastPreview.tsx
@@ -394,6 +394,7 @@ function PodcastPreview() {
 
                 <button
                   className="hover:text-accent-6"
+                  title={t('sort_episodes')}
                   onClick={() => {
                     setTweakMenu('sort')
                   }}
@@ -402,6 +403,7 @@ function PodcastPreview() {
                 </button>
                 <button
                   className="hover:text-accent-6"
+                  title={t('filter_episodes')}
                   onClick={() => {
                     setTweakMenu('filter')
                   }}
@@ -410,6 +412,7 @@ function PodcastPreview() {
                 </button>
                 <button
                   className="h-6 w-6 hover:text-accent-6"
+                  title={t('podcast_settings')}
                   onClick={() => {
                     setTweakMenu('settings')
                   }}
@@ -418,6 +421,7 @@ function PodcastPreview() {
                 </button>
                 <button
                   className={`w-6 hover:text-accent-6 ${downloading && 'animate-[spin_2s_linear_reverse_infinite]'}`}
+                  title={t('podcast_refresh')}
                   onClick={async () => {
                     loadEpisodes(true)
                   }}


### PR DESCRIPTION
Adds new tooltips for:
 * Sort episodes
 * Filter episodes
 * Podcast settings
 * Refresh podcast

Translations are English-only in this commit.

Fixes #30