### PR TITLE
Add support for fyyd podcast search

### DIFF
--- a/resources/translations/en.json
+++ b/resources/translations/en.json
@@ -93,5 +93,7 @@
   "import_opml": "Import OPML file subscriptions",
   "export_opml": "Export subscriptions to OPML file",
   "change_podcast_cover": "Change the podcast cover",
-  "podcast_cover_url": "URL to the podcast cover"
+  "podcast_cover_url": "URL to the podcast cover",
+  "search_apple": "iTunes",
+  "search_fyyd": "fyyd"
 }

--- a/src/engines/Settings.tsx
+++ b/src/engines/Settings.tsx
@@ -142,6 +142,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       removeFromQueueAtEnd: false,
       removeFromDownloadsAtEnd: false,
     },
+    search: {
+      engine: 'apple'
+    },
     ui: {
       showPinWindowButton: false,
       collapsedLeftMenu: true,

--- a/src/engines/search/base.ts
+++ b/src/engines/search/base.ts
@@ -2,10 +2,14 @@ import { PodcastData } from '../..'
 import { SearchApple } from './apple'
 import { SearchFyyd } from './fyyd'
 
-export async function SearchPodcast(term: string): Promise<Array<PodcastData>> {
-  // no more options right now
-
-  // TODO: Figure out how to dedupe results before merging.
-  //return SearchApple(term)
-  return SearchFyyd(term)
+export async function SearchPodcast(term: string, searchEngine: string): Promise<Array<PodcastData>> {
+  // Perform search with selected search engine.
+  switch(searchEngine) {
+    case "apple":
+      return SearchApple(term);
+    case "fyyd":
+      return SearchFyyd(term);
+    default:
+      throw new Error("Unexpected searchEngine value");
+  }
 }

--- a/src/engines/search/base.ts
+++ b/src/engines/search/base.ts
@@ -1,7 +1,11 @@
 import { PodcastData } from '../..'
 import { SearchApple } from './apple'
+import { SearchFyyd } from './fyyd'
 
 export async function SearchPodcast(term: string): Promise<Array<PodcastData>> {
   // no more options right now
-  return SearchApple(term)
+
+  // TODO: Figure out how to dedupe results before merging.
+  //return SearchApple(term)
+  return SearchFyyd(term)
 }

--- a/src/engines/search/fyyd.ts
+++ b/src/engines/search/fyyd.ts
@@ -1,0 +1,30 @@
+import { PodcastData } from '../..'
+import { fetch as tauriFetch } from '@tauri-apps/api/http'
+
+export async function SearchFyyd(term: string): Promise<Array<PodcastData>> {
+  const searchParams = new URLSearchParams({
+    'count': '40',
+    'term': term.trim()
+  });
+  const url = `https://api.fyyd.de/0.2/search/podcast?${searchParams.toString()}`
+
+  const response = await tauriFetch(url); // fetching from backend to avoid cors errors
+  const apiResults = (await response.data as any).data;
+
+  // Put results into a map using the returned search rank as keys.
+  const resultsMap = new Map();
+  for (const result of apiResults) {
+    if (result.xmlURL) {
+      resultsMap.set(result.rank, {
+        podcastName: result.title,
+        artistName: result.author,
+        coverUrl: result.thumbImageURL,
+        coverUrlLarge: result.imgURL,
+        feedUrl: result.xmlURL,
+      });
+    }
+  }
+
+  // Convert our map into an array sorted by search rank.
+  return Array.from(resultsMap.values()).sort();
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -88,6 +88,9 @@ export interface Settings {
     removeFromQueueAtEnd: boolean
     removeFromDownloadsAtEnd: boolean
   }
+  search: {
+    engine: string
+  }
   ui: {
     showPinWindowButton: boolean
     collapsedLeftMenu: boolean


### PR DESCRIPTION
Adds the ability to search with fyyd in addition to Apple/iTunes. The last used search engine is always used unless the config file contains an invalid search engine, in which case it will default to iTunes.

Fixes #61